### PR TITLE
Remove unnecessary requires

### DIFF
--- a/lib/hydra.rb
+++ b/lib/hydra.rb
@@ -1,10 +1,2 @@
 require "hydra/version"
 require 'hydra/head'
-require 'active-fedora'
-require 'rails'
-require 'om'
-require 'solrizer'
-require 'rsolr'
-require 'blacklight'
-require 'nokogiri'
-require 'rubydora'


### PR DESCRIPTION
Currently it's broken because there is no "rubydora" in the gemspec