### PR TITLE
Bump dependencies to work with newer Blacklight and remove deprecation warnings

### DIFF
--- a/doc/Lesson:-build-a-book-model.md
+++ b/doc/Lesson:-build-a-book-model.md
@@ -104,7 +104,7 @@ Now we'll open the `rails console` again and see how to work with our book.
 
 ```text
 b = Book.create(title: 'Anna Karenina', author: 'Tolstoy, Leo')
- => #<Book pid:"changeme:1", title:["Anna Karenina"], author:["Tolstoy, Leo"]> 
+ => #<Book pid:"changeme:1", title:"Anna Karenina", author:"Tolstoy, Leo"> 
 ```
 
 We've created a new Book object in the repository.  You can see that it has a pid (Fedora Commons persistence identifier) of 'changeme:1'.  Because you set title and author to delegate to the descMetadata datastream, they are stored in that datastream's XML and can be accessed either through the delegated methods on the Book, or by going specifically to the datastream. 

--- a/hydra.gemspec
+++ b/hydra.gemspec
@@ -23,14 +23,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license = 'APACHE2'
 
-  gem.add_dependency 'hydra-head', '~> 8.0.0'
+  gem.add_dependency 'hydra-head', '~> 8.1.0'
   gem.add_dependency 'jettywrapper', '~> 1.8.3'
-  gem.add_dependency 'active-fedora', '~> 8.0.0'
+  gem.add_dependency 'active-fedora', '~> 8.0.1'
   gem.add_dependency 'rails', '>= 3.2.15', '< 5.0'
   gem.add_dependency 'om', '~> 3.1.0'
   gem.add_dependency 'solrizer', '~> 3.3.0'
   gem.add_dependency 'rsolr', '~> 1.0.12'
-  gem.add_dependency 'blacklight', '~> 5.9.0'
+  gem.add_dependency 'blacklight', '~> 5.10.0'
   gem.add_dependency 'nokogiri', '~> 1.6.5'
   gem.add_dependency 'rubydora', '~> 1.8.1'
   gem.add_dependency 'nom-xml', '~> 0.5.2'


### PR DESCRIPTION
Also fixed one example from a run through Dive into Hydra.  After this gets merged I plan to release hydra 8.0.