### PR TITLE
Revised text around squashing commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,6 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 
 ### Submitting Changes
 
-[Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
-
 * Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
 * Make sure your branch is up to date with its parent branch (i.e. master)
   * `git checkout master`
@@ -87,7 +85,8 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
   * `git checkout <your-branch>`
   * `git rebase master`
   * It is likely a good idea to run your tests again.
-* Squash the commits for your branch into one commit
+* If you've made more than one commit take a moment to consider whether squashing commits together would help improve their logical grouping.
+  * [Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
   * `git rebase --interactive HEAD~<number-of-commits>` ([See Github help](https://help.github.com/articles/interactive-rebase))
   * To determine the number of commits on your branch: `git log master..<your-branch> --oneline | wc -l`
   * Squashing your branch's changes into one commit is "good form" and helps the person merging your request to see everything that is going on.


### PR DESCRIPTION
Phrased the point to be a guideline rather than a dictate.
This was discussed on the hydra tech call 2015-04-15