### PR TITLE
Put the install generator's code in clean env.

### DIFF
--- a/lib/generators/hydra/install_generator.rb
+++ b/lib/generators/hydra/install_generator.rb
@@ -5,9 +5,11 @@ module Hydra
     desc 'Generate a new hydra project'
 
     def run_other_generators
-      generate("blacklight:install --devise")
-      generate('hydra:head -f')
-      rake('db:migrate')
+      Bundler.with_clean_env do
+        generate("blacklight:install --devise")
+        generate('hydra:head -f')
+        rake('db:migrate')
+      end
     end
   end
 end


### PR DESCRIPTION
The generate() methods in the install generator are failing
when triggered in a rails application template.  Putting them
in Bundler.with_clean_env makes them work.  This is a common
practice, and examples of it can be found in Hydra::HeadGenerator.