### PR TITLE
Updating solr_wrapper dependency to remove 404

### DIFF
--- a/hydra.gemspec
+++ b/hydra.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.license = 'APACHE2'
 
   gem.add_dependency 'fcrepo_wrapper', '~> 0.5.1'
-  gem.add_dependency 'solr_wrapper', '~> 0.12.1'
+  gem.add_dependency 'solr_wrapper', '~> 0.13.1'
   gem.add_dependency 'active-fedora', '~> 10.0.0'
   gem.add_dependency 'hydra-head', '~> 10.0.0'
   gem.add_dependency 'rails', '~> 4.2'


### PR DESCRIPTION
Following the Dive into Hydra tutorial, we encountered a problem with
SOLR working using solr_wrapper 0.12.1 (see call stack below). After
posting on Hydra slack, we received an answer from Michael Tribone
saying that he had to update sufia's solr_wrapper.

Without this change, the Dive into Hydra tutorial does not work.

```console
hydra-demo master % solr_wrapper -d solr/config/ --collection_name hydra-development
Loading configuration from /Users/lrobins5/git/hydra-demo/.solr_wrapper
Starting Solr 6.0.1 on port 8983 ...
       ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:359:in `open_http': 404 Not Found (OpenURI::HTTPError)--=---=---=---=---| 0% ( ETA: ??:??:?? )
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:737:in `buffer_open'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:212:in `block in open_loop'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:210:in `catch'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:210:in `open_loop'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:151:in `open_uri'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:717:in `open'
  from ./.rbenv/versions/2.3.0/lib/ruby/2.3.0/open-uri.rb:35:in `open'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/lib/solr_wrapper/downloader.rb:7:in `fetch_with_progressbar'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/lib/solr_wrapper/instance.rb:289:in `download'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/lib/solr_wrapper/instance.rb:250:in `extract'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/lib/solr_wrapper/instance.rb:239:in `extract_and_configure'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/lib/solr_wrapper/instance.rb:62:in `wrap'
  from ./.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/solr_wrapper-0.12.1/exe/solr_wrapper:108:in `<top (required)>'
  from ./.rbenv/versions/2.3.0/bin/solr_wrapper:22:in `load'
  from ./.rbenv/versions/2.3.0/bin/solr_wrapper:22:in `<main>'
```console